### PR TITLE
15 dark colorscheme

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,6 @@ indent_style = tab
 
 [*.{js,json,yml}]
 indent_size = 2
+
+[*.tsx]
+indent_size = 2

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 import { Route, Switch } from 'react-router';
-import { BrowserRouter } from 'react-router-dom';
 
-import Themer from './components/Themer';
 import Layout from './layout';
 import BugPage from './pages/bug';
 import ListPage from './pages/list';
-import { defaultLightTheme, defaultDarkTheme } from './themes/index';
 
 export default function App() {
   return (
-    <Themer lightTheme={defaultLightTheme} darkTheme={defaultDarkTheme}>
-      <BrowserRouter>
-        <Layout>
-          <Switch>
-            <Route path="/" exact component={ListPage} />
-            <Route path="/bug/:id" exact component={BugPage} />
-          </Switch>
-        </Layout>
-      </BrowserRouter>
-    </Themer>
+    <Layout>
+      <Switch>
+        <Route path="/" exact component={ListPage} />
+        <Route path="/bug/:id" exact component={BugPage} />
+      </Switch>
+    </Layout>
   );
 }

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -6,10 +6,11 @@ import Themer from './components/Themer';
 import Layout from './layout';
 import BugPage from './pages/bug';
 import ListPage from './pages/list';
+import { defaultLightTheme, defaultDarkTheme } from './theme';
 
 export default function App() {
   return (
-    <Themer>
+    <Themer lightTheme={defaultLightTheme} darkTheme={defaultDarkTheme}>
       <BrowserRouter>
         <Layout>
           <Switch>

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -6,7 +6,7 @@ import Themer from './components/Themer';
 import Layout from './layout';
 import BugPage from './pages/bug';
 import ListPage from './pages/list';
-import { defaultLightTheme, defaultDarkTheme } from './theme';
+import { defaultLightTheme, defaultDarkTheme } from './themes/index';
 
 export default function App() {
   return (

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 import { Route, Switch } from 'react-router';
+import { BrowserRouter } from 'react-router-dom';
 
+import Themer from './components/Themer';
 import Layout from './layout';
 import BugPage from './pages/bug';
 import ListPage from './pages/list';
 
 export default function App() {
   return (
-    <Layout>
-      <Switch>
-        <Route path="/" exact component={ListPage} />
-        <Route path="/bug/:id" exact component={BugPage} />
-      </Switch>
-    </Layout>
+    <Themer>
+      <BrowserRouter>
+        <Layout>
+          <Switch>
+            <Route path="/" exact component={ListPage} />
+            <Route path="/bug/:id" exact component={BugPage} />
+          </Switch>
+        </Layout>
+      </BrowserRouter>
+    </Themer>
   );
 }

--- a/webui/src/components/Themer.tsx
+++ b/webui/src/components/Themer.tsx
@@ -1,29 +1,37 @@
 import React, { createContext, useContext, useState } from 'react';
 
-import { ThemeProvider } from '@material-ui/core';
+import { fade, ThemeProvider } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton/IconButton';
 import Tooltip from '@material-ui/core/Tooltip/Tooltip';
 import { Theme } from '@material-ui/core/styles';
 import { NightsStayRounded, WbSunnyRounded } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/styles';
 
 const ThemeContext = createContext({
   toggleMode: () => {},
   mode: '',
 });
 
+const useStyles = makeStyles((theme: Theme) => ({
+  iconButton: {
+    color: fade(theme.palette.primary.contrastText, 0.5),
+  },
+}));
+
 const LightSwitch = () => {
   const { mode, toggleMode } = useContext(ThemeContext);
   const nextMode = mode === 'light' ? 'dark' : 'light';
   const description = `Switch to ${nextMode} theme`;
+  const classes = useStyles();
 
   return (
     <Tooltip title={description}>
-      <IconButton onClick={toggleMode} aria-label={description}>
-        {mode === 'light' ? (
-          <WbSunnyRounded color="secondary" />
-        ) : (
-          <NightsStayRounded color="secondary" />
-        )}
+      <IconButton
+        onClick={toggleMode}
+        aria-label={description}
+        className={classes.iconButton}
+      >
+        {mode === 'light' ? <WbSunnyRounded /> : <NightsStayRounded />}
       </IconButton>
     </Tooltip>
   );

--- a/webui/src/components/Themer.tsx
+++ b/webui/src/components/Themer.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 
-import { ThemeProvider, useMediaQuery } from '@material-ui/core';
+import { ThemeProvider } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton/IconButton';
 import Tooltip from '@material-ui/core/Tooltip/Tooltip';
 import { Theme } from '@material-ui/core/styles';
@@ -35,22 +35,20 @@ type Props = {
   darkTheme: Theme;
 };
 const Themer = ({ children, lightTheme, darkTheme }: Props) => {
-  const preferseDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const browserMode = preferseDarkMode ? 'dark' : 'light';
   const savedMode = localStorage.getItem('themeMode');
-  const preferedMode = savedMode != null ? savedMode : browserMode;
-  const [curMode, setMode] = useState(preferedMode);
+  const preferedMode = savedMode != null ? savedMode : 'light';
+  const [mode, setMode] = useState(preferedMode);
 
   const toggleMode = () => {
-    const preferedMode = curMode === 'light' ? 'dark' : 'light';
+    const preferedMode = mode === 'light' ? 'dark' : 'light';
     localStorage.setItem('themeMode', preferedMode);
     setMode(preferedMode);
   };
 
-  const preferedTheme = preferedMode === 'dark' ? darkTheme : lightTheme;
+  const preferedTheme = mode === 'dark' ? darkTheme : lightTheme;
 
   return (
-    <ThemeContext.Provider value={{ toggleMode: toggleMode, mode: curMode }}>
+    <ThemeContext.Provider value={{ toggleMode: toggleMode, mode: mode }}>
       <ThemeProvider theme={preferedTheme}>{children}</ThemeProvider>
     </ThemeContext.Provider>
   );

--- a/webui/src/components/Themer.tsx
+++ b/webui/src/components/Themer.tsx
@@ -13,7 +13,8 @@ const ThemeContext = createContext({
 
 const LightSwitch = () => {
   const { mode, toggleMode } = useContext(ThemeContext);
-  const description = `Switch to ${mode === 'light' ? 'dark' : 'light'} theme`;
+  const nextMode = mode === 'light' ? 'dark' : 'light';
+  const description = `Switch to ${nextMode} theme`;
 
   return (
     <Tooltip title={description}>

--- a/webui/src/components/Themer.tsx
+++ b/webui/src/components/Themer.tsx
@@ -1,19 +1,10 @@
 import React, { createContext, useContext, useState } from 'react';
 
-import { PaletteType, ThemeProvider, useMediaQuery } from '@material-ui/core';
+import { ThemeProvider, useMediaQuery } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton/IconButton';
 import Tooltip from '@material-ui/core/Tooltip/Tooltip';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { Theme } from '@material-ui/core/styles';
 import { NightsStayRounded, WbSunnyRounded } from '@material-ui/icons';
-
-const defaultTheme = {
-  palette: {
-    type: 'light',
-    primary: {
-      main: '#263238',
-    },
-  },
-};
 
 const ThemeContext = createContext({
   toggleMode: () => {},
@@ -22,10 +13,11 @@ const ThemeContext = createContext({
 
 const LightSwitch = () => {
   const { mode, toggleMode } = useContext(ThemeContext);
+  const description = `Switch to ${mode === 'light' ? 'dark' : 'light'} theme`;
 
   return (
-    <Tooltip title="Toggle Dark-/Lightmode">
-      <IconButton onClick={toggleMode} aria-label="Toggle Dark-/Lightmode">
+    <Tooltip title={description}>
+      <IconButton onClick={toggleMode} aria-label={description}>
         {mode === 'light' ? (
           <WbSunnyRounded color="secondary" />
         ) : (
@@ -36,40 +28,29 @@ const LightSwitch = () => {
   );
 };
 
-type Props = { children: React.ReactNode };
-const Themer = ({ children }: Props) => {
-  const [theme, setTheme] = useState(defaultTheme);
+type Props = {
+  children: React.ReactNode;
+  lightTheme: Theme;
+  darkTheme: Theme;
+};
+const Themer = ({ children, lightTheme, darkTheme }: Props) => {
   const preferseDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
   const browserMode = preferseDarkMode ? 'dark' : 'light';
-  const preferedMode = localStorage.getItem('themeMode');
-  const curMode = preferedMode != null ? preferedMode : browserMode;
-
-  const adjustedTheme = {
-    ...theme,
-    palette: {
-      ...theme.palette,
-      type: (curMode === 'dark' ? 'dark' : 'light') as PaletteType,
-    },
-  };
+  const savedMode = localStorage.getItem('themeMode');
+  const preferedMode = savedMode != null ? savedMode : browserMode;
+  const [curMode, setMode] = useState(preferedMode);
 
   const toggleMode = () => {
-    const preferedMode = curMode === 'dark' ? 'light' : 'dark';
+    const preferedMode = curMode === 'light' ? 'dark' : 'light';
     localStorage.setItem('themeMode', preferedMode);
-    const adjustedTheme = {
-      ...theme,
-      palette: {
-        ...theme.palette,
-        type: preferedMode as PaletteType,
-      },
-    };
-    setTheme(adjustedTheme);
+    setMode(preferedMode);
   };
+
+  const preferedTheme = preferedMode === 'dark' ? darkTheme : lightTheme;
 
   return (
     <ThemeContext.Provider value={{ toggleMode: toggleMode, mode: curMode }}>
-      <ThemeProvider theme={createMuiTheme(adjustedTheme)}>
-        {children}
-      </ThemeProvider>
+      <ThemeProvider theme={preferedTheme}>{children}</ThemeProvider>
     </ThemeContext.Provider>
   );
 };

--- a/webui/src/components/Themer.tsx
+++ b/webui/src/components/Themer.tsx
@@ -1,0 +1,64 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+
+import { ThemeProvider } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton/IconButton';
+import Tooltip from '@material-ui/core/Tooltip/Tooltip';
+import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { NightsStayRounded, WbSunnyRounded } from '@material-ui/icons';
+
+const defaultTheme: ThemeOptions = {
+  palette: {
+    type: 'light',
+    primary: {
+      main: '#263238',
+    },
+  },
+};
+
+const ThemeContext = createContext({
+  toggleMode: () => {},
+  mode: '',
+});
+
+const LightSwitch = () => {
+  const { mode, toggleMode } = useContext(ThemeContext);
+
+  return (
+    <Tooltip title="Toggle Dark-/Lightmode">
+      <IconButton onClick={toggleMode} aria-label="Toggle Dark-/Lightmode">
+        {mode === 'light' ? (
+          <WbSunnyRounded color="secondary" />
+        ) : (
+          <NightsStayRounded color="secondary" />
+        )}
+      </IconButton>
+    </Tooltip>
+  );
+};
+
+type Props = { children: React.ReactNode };
+const Themer = ({ children }: Props) => {
+  const [theme, setTheme] = useState(defaultTheme);
+
+  const toggleMode = useCallback(() => {
+    const newMode = theme.palette?.type === 'dark' ? 'light' : 'dark';
+    const adjustedTheme: ThemeOptions = {
+      ...theme,
+      palette: {
+        ...theme.palette,
+        type: newMode,
+      },
+    };
+    setTheme(adjustedTheme);
+  }, [theme, setTheme]);
+
+  const newMode = theme.palette?.type === 'dark' ? 'light' : 'dark';
+
+  return (
+    <ThemeContext.Provider value={{ toggleMode: toggleMode, mode: newMode }}>
+      <ThemeProvider theme={createMuiTheme(theme)}> {children} </ThemeProvider>
+    </ThemeContext.Provider>
+  );
+};
+
+export { Themer as default, LightSwitch };

--- a/webui/src/components/Themer.tsx
+++ b/webui/src/components/Themer.tsx
@@ -1,12 +1,12 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
-import { ThemeProvider } from '@material-ui/core';
+import { PaletteType, ThemeProvider, useMediaQuery } from '@material-ui/core';
 import IconButton from '@material-ui/core/IconButton/IconButton';
 import Tooltip from '@material-ui/core/Tooltip/Tooltip';
-import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
+import { createMuiTheme } from '@material-ui/core/styles';
 import { NightsStayRounded, WbSunnyRounded } from '@material-ui/icons';
 
-const defaultTheme: ThemeOptions = {
+const defaultTheme = {
   palette: {
     type: 'light',
     primary: {
@@ -39,24 +39,37 @@ const LightSwitch = () => {
 type Props = { children: React.ReactNode };
 const Themer = ({ children }: Props) => {
   const [theme, setTheme] = useState(defaultTheme);
+  const preferseDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+  const browserMode = preferseDarkMode ? 'dark' : 'light';
+  const preferedMode = localStorage.getItem('themeMode');
+  const curMode = preferedMode != null ? preferedMode : browserMode;
 
-  const toggleMode = useCallback(() => {
-    const newMode = theme.palette?.type === 'dark' ? 'light' : 'dark';
-    const adjustedTheme: ThemeOptions = {
+  const adjustedTheme = {
+    ...theme,
+    palette: {
+      ...theme.palette,
+      type: (curMode === 'dark' ? 'dark' : 'light') as PaletteType,
+    },
+  };
+
+  const toggleMode = () => {
+    const preferedMode = curMode === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('themeMode', preferedMode);
+    const adjustedTheme = {
       ...theme,
       palette: {
         ...theme.palette,
-        type: newMode,
+        type: preferedMode as PaletteType,
       },
     };
     setTheme(adjustedTheme);
-  }, [theme, setTheme]);
-
-  const newMode = theme.palette?.type === 'dark' ? 'light' : 'dark';
+  };
 
   return (
-    <ThemeContext.Provider value={{ toggleMode: toggleMode, mode: newMode }}>
-      <ThemeProvider theme={createMuiTheme(theme)}> {children} </ThemeProvider>
+    <ThemeContext.Provider value={{ toggleMode: toggleMode, mode: curMode }}>
+      <ThemeProvider theme={createMuiTheme(adjustedTheme)}>
+        {children}
+      </ThemeProvider>
     </ThemeContext.Provider>
   );
 };

--- a/webui/src/index.tsx
+++ b/webui/src/index.tsx
@@ -1,13 +1,20 @@
 import { ApolloProvider } from '@apollo/client';
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import App from './App';
 import apolloClient from './apollo';
+import Themer from './components/Themer';
+import { defaultLightTheme, defaultDarkTheme } from './themes/index';
 
 ReactDOM.render(
   <ApolloProvider client={apolloClient}>
-    <App />
+    <BrowserRouter>
+      <Themer lightTheme={defaultLightTheme} darkTheme={defaultDarkTheme}>
+        <App />
+      </Themer>
+    </BrowserRouter>
   </ApolloProvider>,
   document.getElementById('root')
 );

--- a/webui/src/index.tsx
+++ b/webui/src/index.tsx
@@ -1,21 +1,13 @@
 import { ApolloProvider } from '@apollo/client';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { BrowserRouter } from 'react-router-dom';
-
-import ThemeProvider from '@material-ui/styles/ThemeProvider';
 
 import App from './App';
 import apolloClient from './apollo';
-import theme from './theme';
 
 ReactDOM.render(
   <ApolloProvider client={apolloClient}>
-    <BrowserRouter>
-      <ThemeProvider theme={theme}>
-        <App />
-      </ThemeProvider>
-    </BrowserRouter>
+    <App />
   </ApolloProvider>,
   document.getElementById('root')
 );

--- a/webui/src/layout/Header.tsx
+++ b/webui/src/layout/Header.tsx
@@ -5,6 +5,8 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import { makeStyles } from '@material-ui/core/styles';
 
+import { LightSwitch } from 'src/components/Themer';
+
 import CurrentIdentity from './CurrentIdentity';
 
 const useStyles = makeStyles((theme) => ({
@@ -20,6 +22,9 @@ const useStyles = makeStyles((theme) => ({
     textDecoration: 'none',
     display: 'flex',
     alignItems: 'center',
+  },
+  lightSwitch: {
+    padding: '0 20px',
   },
   logo: {
     height: '42px',
@@ -39,6 +44,9 @@ function Header() {
             git-bug
           </Link>
           <div className={classes.filler}></div>
+          <div className={classes.lightSwitch}>
+            <LightSwitch />
+          </div>
           <CurrentIdentity />
         </Toolbar>
       </AppBar>

--- a/webui/src/layout/Header.tsx
+++ b/webui/src/layout/Header.tsx
@@ -5,7 +5,7 @@ import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import { makeStyles } from '@material-ui/core/styles';
 
-import { LightSwitch } from 'src/components/Themer';
+import { LightSwitch } from '../components/Themer';
 
 import CurrentIdentity from './CurrentIdentity';
 

--- a/webui/src/pages/bug/Message.tsx
+++ b/webui/src/pages/bug/Message.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Paper from '@material-ui/core/Paper';
-import { fade, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 import Author, { Avatar } from 'src/components/Author';
 import Content from 'src/components/Content';
@@ -31,7 +31,9 @@ const useStyles = makeStyles((theme) => ({
     padding: '0.5rem 1rem',
     borderBottom: `1px solid ${theme.palette.divider}`,
     display: 'flex',
-    backgroundColor: fade(theme.palette.text.hint, 0.05),
+    borderTopRightRadius: theme.shape.borderRadius,
+    borderTopLeftRadius: theme.shape.borderRadius,
+    backgroundColor: theme.palette.info.main,
   },
   title: {
     flex: 1,

--- a/webui/src/pages/bug/Message.tsx
+++ b/webui/src/pages/bug/Message.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import Paper from '@material-ui/core/Paper';
-import { makeStyles } from '@material-ui/core/styles';
+import { fade, makeStyles } from '@material-ui/core/styles';
 
 import Author, { Avatar } from 'src/components/Author';
 import Content from 'src/components/Content';
@@ -27,11 +27,11 @@ const useStyles = makeStyles((theme) => ({
   },
   header: {
     ...theme.typography.body1,
-    color: '#444',
+    color: theme.palette.text.secondary,
     padding: '0.5rem 1rem',
-    borderBottom: '1px solid #ddd',
+    borderBottom: `1px solid ${theme.palette.divider}`,
     display: 'flex',
-    backgroundColor: '#e2f1ff',
+    backgroundColor: fade(theme.palette.text.hint, 0.05),
   },
   title: {
     flex: 1,

--- a/webui/src/pages/bug/Message.tsx
+++ b/webui/src/pages/bug/Message.tsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles((theme) => ({
   },
   body: {
     ...theme.typography.body2,
-    padding: '0 1rem',
+    padding: '0.5rem',
   },
 }));
 

--- a/webui/src/pages/list/Filter.tsx
+++ b/webui/src/pages/list/Filter.tsx
@@ -65,7 +65,7 @@ function stringify(params: Query): string {
 const useStyles = makeStyles((theme) => ({
   element: {
     ...theme.typography.body2,
-    color: '#444',
+    color: theme.palette.text.secondary,
     padding: theme.spacing(0, 1),
     fontWeight: 400,
     textDecoration: 'none',
@@ -75,7 +75,7 @@ const useStyles = makeStyles((theme) => ({
   },
   itemActive: {
     fontWeight: 600,
-    color: '#333',
+    color: theme.palette.text.primary,
   },
   icon: {
     paddingRight: theme.spacing(0.5),

--- a/webui/src/pages/list/FilterToolbar.tsx
+++ b/webui/src/pages/list/FilterToolbar.tsx
@@ -3,7 +3,7 @@ import { LocationDescriptor } from 'history';
 import React from 'react';
 
 import Toolbar from '@material-ui/core/Toolbar';
-import { makeStyles } from '@material-ui/core/styles';
+import { fade, makeStyles } from '@material-ui/core/styles';
 import CheckCircleOutline from '@material-ui/icons/CheckCircleOutline';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
 
@@ -19,8 +19,8 @@ import { useBugCountQuery } from './FilterToolbar.generated';
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
-    backgroundColor: theme.palette.grey['100'],
-    borderColor: theme.palette.grey['300'],
+    backgroundColor: fade(theme.palette.text.hint, 0.05),
+    borderColor: theme.palette.divider,
     borderWidth: '1px 0',
     borderStyle: 'solid',
     margin: theme.spacing(0, -1),

--- a/webui/src/pages/list/FilterToolbar.tsx
+++ b/webui/src/pages/list/FilterToolbar.tsx
@@ -3,7 +3,7 @@ import { LocationDescriptor } from 'history';
 import React from 'react';
 
 import Toolbar from '@material-ui/core/Toolbar';
-import { fade, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import CheckCircleOutline from '@material-ui/icons/CheckCircleOutline';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
 
@@ -19,7 +19,7 @@ import { useBugCountQuery } from './FilterToolbar.generated';
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
-    backgroundColor: fade(theme.palette.text.hint, 0.05),
+    backgroundColor: theme.palette.primary.light,
     borderColor: theme.palette.divider,
     borderWidth: '1px 0',
     borderStyle: 'solid',

--- a/webui/src/pages/list/ListQuery.tsx
+++ b/webui/src/pages/list/ListQuery.tsx
@@ -42,10 +42,10 @@ const useStyles = makeStyles<Theme, StylesProps>((theme) => ({
   },
   search: {
     borderRadius: theme.shape.borderRadius,
-    borderColor: fade(theme.palette.primary.main, 0.2),
+    borderColor: theme.palette.divider,
     borderStyle: 'solid',
     borderWidth: '1px',
-    backgroundColor: fade(theme.palette.primary.main, 0.05),
+    backgroundColor: fade(theme.palette.text.hint, 0.05),
     padding: theme.spacing(0, 1),
     width: ({ searching }) => (searching ? '20rem' : '15rem'),
     transition: theme.transitions.create([

--- a/webui/src/pages/list/ListQuery.tsx
+++ b/webui/src/pages/list/ListQuery.tsx
@@ -5,7 +5,7 @@ import { useLocation, useHistory, Link } from 'react-router-dom';
 import IconButton from '@material-ui/core/IconButton';
 import InputBase from '@material-ui/core/InputBase';
 import Paper from '@material-ui/core/Paper';
-import { fade, makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import ErrorOutline from '@material-ui/icons/ErrorOutline';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
@@ -42,10 +42,11 @@ const useStyles = makeStyles<Theme, StylesProps>((theme) => ({
   },
   search: {
     borderRadius: theme.shape.borderRadius,
+    color: theme.palette.text.secondary,
     borderColor: theme.palette.divider,
     borderStyle: 'solid',
     borderWidth: '1px',
-    backgroundColor: fade(theme.palette.text.hint, 0.05),
+    backgroundColor: theme.palette.primary.light,
     padding: theme.spacing(0, 1),
     width: ({ searching }) => (searching ? '20rem' : '15rem'),
     transition: theme.transitions.create([
@@ -55,13 +56,11 @@ const useStyles = makeStyles<Theme, StylesProps>((theme) => ({
     ]),
   },
   searchFocused: {
-    borderColor: fade(theme.palette.primary.main, 0.4),
     backgroundColor: theme.palette.background.paper,
-    width: '20rem!important',
   },
   placeholderRow: {
     padding: theme.spacing(1),
-    borderBottomColor: theme.palette.grey['300'],
+    borderBottomColor: theme.palette.divider,
     borderBottomWidth: '1px',
     borderBottomStyle: 'solid',
     display: 'flex',
@@ -77,7 +76,8 @@ const useStyles = makeStyles<Theme, StylesProps>((theme) => ({
     ...theme.typography.h5,
     padding: theme.spacing(8),
     textAlign: 'center',
-    borderBottomColor: theme.palette.grey['300'],
+    color: theme.palette.text.hint,
+    borderBottomColor: theme.palette.divider,
     borderBottomWidth: '1px',
     borderBottomStyle: 'solid',
     '& > p': {
@@ -85,12 +85,15 @@ const useStyles = makeStyles<Theme, StylesProps>((theme) => ({
     },
   },
   errorBox: {
-    color: theme.palette.error.main,
+    color: theme.palette.error.dark,
     '& > pre': {
       fontSize: '1rem',
       textAlign: 'left',
-      backgroundColor: theme.palette.grey['900'],
-      color: theme.palette.common.white,
+      borderColor: theme.palette.divider,
+      borderWidth: '1px',
+      borderRadius: theme.shape.borderRadius,
+      borderStyle: 'solid',
+      color: theme.palette.text.primary,
       marginTop: theme.spacing(4),
       padding: theme.spacing(2, 3),
     },

--- a/webui/src/theme.ts
+++ b/webui/src/theme.ts
@@ -2,6 +2,7 @@ import { createMuiTheme } from '@material-ui/core/styles';
 
 const theme = createMuiTheme({
   palette: {
+    type: 'dark',
     primary: {
       main: '#263238',
     },

--- a/webui/src/theme.ts
+++ b/webui/src/theme.ts
@@ -1,6 +1,15 @@
 import { createMuiTheme } from '@material-ui/core/styles';
 
-const theme = createMuiTheme({
+const defaultLightTheme = createMuiTheme({
+  palette: {
+    type: 'light',
+    primary: {
+      main: '#263238',
+    },
+  },
+});
+
+const defaultDarkTheme = createMuiTheme({
   palette: {
     type: 'dark',
     primary: {
@@ -9,4 +18,4 @@ const theme = createMuiTheme({
   },
 });
 
-export default theme;
+export { defaultLightTheme, defaultDarkTheme };

--- a/webui/src/themes/DefaultDark.ts
+++ b/webui/src/themes/DefaultDark.ts
@@ -5,6 +5,14 @@ const defaultDarkTheme = createMuiTheme({
     type: 'dark',
     primary: {
       main: '#263238',
+      light: '#525252',
+    },
+    error: {
+      main: '#f44336',
+      dark: '#ff4949',
+    },
+    info: {
+      main: '#2a393e',
     },
   },
 });

--- a/webui/src/themes/DefaultDark.ts
+++ b/webui/src/themes/DefaultDark.ts
@@ -1,0 +1,12 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+const defaultDarkTheme = createMuiTheme({
+  palette: {
+    type: 'dark',
+    primary: {
+      main: '#263238',
+    },
+  },
+});
+
+export default defaultDarkTheme;

--- a/webui/src/themes/DefaultLight.ts
+++ b/webui/src/themes/DefaultLight.ts
@@ -5,6 +5,13 @@ const defaultLightTheme = createMuiTheme({
     type: 'light',
     primary: {
       main: '#263238',
+      light: '#f5f5f5',
+    },
+    info: {
+      main: '#e2f1ff',
+    },
+    text: {
+      secondary: '#555',
     },
   },
 });

--- a/webui/src/themes/DefaultLight.ts
+++ b/webui/src/themes/DefaultLight.ts
@@ -9,13 +9,4 @@ const defaultLightTheme = createMuiTheme({
   },
 });
 
-const defaultDarkTheme = createMuiTheme({
-  palette: {
-    type: 'dark',
-    primary: {
-      main: '#263238',
-    },
-  },
-});
-
-export { defaultLightTheme, defaultDarkTheme };
+export default defaultLightTheme;

--- a/webui/src/themes/index.ts
+++ b/webui/src/themes/index.ts
@@ -1,0 +1,4 @@
+import defaultDarkTheme from './DefaultDark';
+import defaultLightTheme from './DefaultLight';
+
+export { defaultLightTheme, defaultDarkTheme };


### PR DESCRIPTION
Might close #15 when merged.
Most color values use only the text-palette as this is the palette which is adjustable via the palette.type flag as described [here](https://material-ui.com/customization/palette/#dark-mode).
This means that changes to the "colorful"-palettes won't be reflected on the overall theme.

Currently it looks like, that a generic "light/dark"-Mode is incompatible with the colorscheme-editor. Unless the user only focuses on the palette.text, palette.divider and palette.background values. Which will prevent the text to be grayish.
Maybe this current implementation has to be dropped for multiple separate themes and the mode-switch should only refer to the two hard-coded themes. The problem with this might be, that the whole color-palette must be alterable by the color-editor, as the user doesn't know which specific palette-field is used. E.g. deeporange['300']. May be only the gray palette has to be changed...

TLDR - Two possible solutions:
- Implement colorscheme-editor with only field for the above mentioned light/dark convertible color palettes.
- Implement light and dark mode via two separate themes and hard-code them for the mode-switch. User defined dark or light themes are not usable from the mode-switch only the default ones. Might also have to specify the whole gray-palette...

 