### PR TITLE
TEST: Refactor combined id rework 2

### DIFF
--- a/api/graphql/resolvers/mutation.go
+++ b/api/graphql/resolvers/mutation.go
@@ -27,7 +27,7 @@ func (r mutationResolver) getRepo(ref *string) (*cache.RepoCache, error) {
 	return r.cache.DefaultRepo()
 }
 
-func (r mutationResolver) getBug(repoRef *string, bugPrefix string) (*cache.RepoCache, *cache.BugCache, error) {
+func (r mutationResolver) getBug(repoRef *string, bugPrefix entity.Id) (*cache.RepoCache, *cache.BugCache, error) {
 	repo, err := r.getRepo(repoRef)
 	if err != nil {
 		return nil, nil, err
@@ -69,7 +69,7 @@ func (r mutationResolver) NewBug(ctx context.Context, input models.NewBugInput) 
 }
 
 func (r mutationResolver) AddComment(ctx context.Context, input models.AddCommentInput) (*models.AddCommentPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (r mutationResolver) AddComment(ctx context.Context, input models.AddCommen
 }
 
 func (r mutationResolver) AddCommentAndClose(ctx context.Context, input models.AddCommentAndCloseBugInput) (*models.AddCommentAndCloseBugPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (r mutationResolver) AddCommentAndClose(ctx context.Context, input models.A
 }
 
 func (r mutationResolver) AddCommentAndReopen(ctx context.Context, input models.AddCommentAndReopenBugInput) (*models.AddCommentAndReopenBugPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (r mutationResolver) AddCommentAndReopen(ctx context.Context, input models.
 }
 
 func (r mutationResolver) EditComment(ctx context.Context, input models.EditCommentInput) (*models.EditCommentPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (r mutationResolver) EditComment(ctx context.Context, input models.EditComm
 }
 
 func (r mutationResolver) ChangeLabels(ctx context.Context, input *models.ChangeLabelInput) (*models.ChangeLabelPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (r mutationResolver) ChangeLabels(ctx context.Context, input *models.Change
 }
 
 func (r mutationResolver) OpenBug(ctx context.Context, input models.OpenBugInput) (*models.OpenBugPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -279,7 +279,7 @@ func (r mutationResolver) OpenBug(ctx context.Context, input models.OpenBugInput
 }
 
 func (r mutationResolver) CloseBug(ctx context.Context, input models.CloseBugInput) (*models.CloseBugPayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -307,7 +307,7 @@ func (r mutationResolver) CloseBug(ctx context.Context, input models.CloseBugInp
 }
 
 func (r mutationResolver) SetTitle(ctx context.Context, input models.SetTitleInput) (*models.SetTitlePayload, error) {
-	repo, b, err := r.getBug(input.RepoRef, input.Prefix)
+	repo, b, err := r.getBug(input.RepoRef, entity.Id(input.Prefix))
 	if err != nil {
 		return nil, err
 	}

--- a/api/graphql/resolvers/mutation.go
+++ b/api/graphql/resolvers/mutation.go
@@ -187,10 +187,13 @@ func (r mutationResolver) EditComment(ctx context.Context, input models.EditComm
 		return nil, err
 	}
 
+	//NOTE target is here the comment id (a timeline item id) so must
+	//split to op id.
+	_, opId := entity.SeparateIds(entity.CombinedId(input.Target))
 	op, err := b.EditCommentRaw(
 		author,
 		time.Now().Unix(),
-		entity.Id(input.Target),
+		opId,
 		text.Cleanup(input.Message),
 		nil,
 	)

--- a/api/graphql/resolvers/repo.go
+++ b/api/graphql/resolvers/repo.go
@@ -86,7 +86,7 @@ func (repoResolver) AllBugs(_ context.Context, obj *models.Repository, after *st
 }
 
 func (repoResolver) Bug(_ context.Context, obj *models.Repository, prefix string) (models.BugWrapper, error) {
-	excerpt, err := obj.Repo.ResolveBugExcerptPrefix(prefix)
+	excerpt, err := obj.Repo.ResolveBugExcerptPrefix(entity.Id(prefix))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (repoResolver) AllIdentities(_ context.Context, obj *models.Repository, aft
 }
 
 func (repoResolver) Identity(_ context.Context, obj *models.Repository, prefix string) (models.IdentityWrapper, error) {
-	excerpt, err := obj.Repo.ResolveIdentityExcerptPrefix(prefix)
+	excerpt, err := obj.Repo.ResolveIdentityExcerptPrefix(entity.Id(prefix))
 	if err != nil {
 		return nil, err
 	}

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -223,11 +223,12 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		// we should check for "changed the description" notes and compare issue texts
 		// TODO: Check only one time and ignore next 'description change' within one issue
 		if errResolve == cache.ErrNoMatchingOp && issue.Description != firstComment.Message {
+			_, commentId := entity.SeparateIds(string(firstComment.Id()))
 			// comment edition
 			op, err := b.EditCommentRaw(
 				author,
 				note.UpdatedAt.Unix(),
-				firstComment.Id(),
+				entity.Id(commentId),
 				text.Cleanup(issue.Description),
 				map[string]string{
 					metaKeyGitlabId: gitlabID,
@@ -266,18 +267,19 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		// if comment was already exported
 
 		// search for last comment update
-		comment, err := b.Snapshot().SearchComment(id)
+		comment, err := b.Snapshot().SearchComment(entity.CombineIds(b.Snapshot().Id(), id))
 		if err != nil {
 			return err
 		}
 
+		_, commentId := entity.SeparateIds(string(comment.Id()))
 		// compare local bug comment with the new note body
 		if comment.Message != cleanText {
 			// comment edition
 			op, err := b.EditCommentRaw(
 				author,
 				note.UpdatedAt.Unix(),
-				comment.Id(),
+				entity.Id(commentId),
 				cleanText,
 				nil,
 			)

--- a/bridge/gitlab/import.go
+++ b/bridge/gitlab/import.go
@@ -223,7 +223,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 		// we should check for "changed the description" notes and compare issue texts
 		// TODO: Check only one time and ignore next 'description change' within one issue
 		if errResolve == cache.ErrNoMatchingOp && issue.Description != firstComment.Message {
-			_, commentId := entity.SeparateIds(string(firstComment.Id()))
+			_, commentId := entity.SeparateIds(firstComment.Id())
 			// comment edition
 			op, err := b.EditCommentRaw(
 				author,
@@ -272,7 +272,7 @@ func (gi *gitlabImporter) ensureNote(repo *cache.RepoCache, b *cache.BugCache, n
 			return err
 		}
 
-		_, commentId := entity.SeparateIds(string(comment.Id()))
+		_, commentId := entity.SeparateIds(comment.Id())
 		// compare local bug comment with the new note body
 		if comment.Message != cleanText {
 			// comment edition

--- a/bug/comment.go
+++ b/bug/comment.go
@@ -13,7 +13,7 @@ import (
 type Comment struct {
 	// id should be the result of entity.CombineIds with the Bug id and the id
 	// of the Operation that created the comment
-	id      entity.Id
+	id      entity.CombinedId
 	Author  identity.Interface
 	Message string
 	Files   []repository.Hash
@@ -24,7 +24,7 @@ type Comment struct {
 }
 
 // Id return the Comment identifier
-func (c Comment) Id() entity.Id {
+func (c Comment) Id() entity.CombinedId {
 	if c.id == "" {
 		// simply panic as it would be a coding error (no id provided at construction)
 		panic("no id")

--- a/bug/op_edit_comment.go
+++ b/bug/op_edit_comment.go
@@ -35,10 +35,23 @@ func (op *EditCommentOperation) Apply(snapshot *Snapshot) {
 	// crypto signature are needed.
 
 	// Recreate the Comment Id to match on
+	fmt.Println("LOG: SnapshotId:", snapshot.Id())
+	fmt.Println("LOG: op.TargetId:", op.Target)
 	commentId := entity.CombineIds(snapshot.Id(), op.Target)
+	fmt.Println("LOG: Created commentId:", commentId)
 
 	var target TimelineItem
 	for i, item := range snapshot.Timeline {
+		fmt.Println("LOG: Timeline item id:", item.Id())
+		//TODO the commentId will never match the timeline item id as the
+		//timelineitem is is op.Target but the commentId is target interleaved
+		//with the bug id!
+		// - Maybe interleave timelineid with snapshot (here)?
+		// - Or separate TimelineId for check...
+		//TODO The timelineitem id is already interleaved with the snapshot id
+		//TODO EditCommentOperation must take a CombinedId as target! But this
+		//conflicts micheals andere here
+		//https://github.com/MichaelMure/git-bug/issues/653#issuecomment-826707391
 		if item.Id() == commentId {
 			target = snapshot.Timeline[i]
 			break
@@ -46,6 +59,7 @@ func (op *EditCommentOperation) Apply(snapshot *Snapshot) {
 	}
 
 	if target == nil {
+		fmt.Println("LOG: Edit is a noop!")
 		// Target not found, edit is a no-op
 		return
 	}
@@ -91,6 +105,7 @@ func (op *EditCommentOperation) Validate() error {
 	}
 
 	if err := op.Target.Validate(); err != nil {
+		fmt.Println("LOG: Validate:", op.Target)
 		return errors.Wrap(err, "target hash is invalid")
 	}
 

--- a/bug/op_edit_comment.go
+++ b/bug/op_edit_comment.go
@@ -52,7 +52,18 @@ func (op *EditCommentOperation) Apply(snapshot *Snapshot) {
 		//TODO EditCommentOperation must take a CombinedId as target! But this
 		//conflicts micheals andere here
 		//https://github.com/MichaelMure/git-bug/issues/653#issuecomment-826707391
-		if item.Id() == commentId {
+
+		//NOTE show_bug.go sparateId only affects the TermUI, not the WebUI!
+		//NOTE GOT THE ERROR!!!
+		//The timeline id (idem.ID) does not match commentId, as commentId
+		//does not correctly reconstruct. Strange is, that the op.TargetId
+		//shouldn't be the Timeline id, as the timeline id is already split...
+		//(see HEAD commit)
+		// SnapshotId: 54bc19b8fae02b4b15dfc5a6d1e7c1ca3ff133de86ef03ab79fb4968dced11a8
+		// op.TargetId: 5544bbc19cb8fa1e02b94b15bdfc58a6d1fe7c1aca3fef1330de862ef03bab79
+		// Created commentId: 5545b4c194b8fabe02bb4b15cdfc51a6d19e7c1cca3fbf1338de86fef03aab79
+		// Timeline item id: 5544bbc19cb8fa1e02b94b15bdfc58a6d1fe7c1aca3fef1330de862ef03bab79
+		if item.Id().HasPrefix(commentId) {
 			target = snapshot.Timeline[i]
 			break
 		}

--- a/bug/op_edit_comment.go
+++ b/bug/op_edit_comment.go
@@ -35,42 +35,17 @@ func (op *EditCommentOperation) Apply(snapshot *Snapshot) {
 	// crypto signature are needed.
 
 	// Recreate the Comment Id to match on
-	fmt.Println("LOG: SnapshotId:", snapshot.Id())
-	fmt.Println("LOG: op.TargetId:", op.Target)
 	commentId := entity.CombineIds(snapshot.Id(), op.Target)
-	fmt.Println("LOG: Created commentId:", commentId)
 
 	var target TimelineItem
 	for i, item := range snapshot.Timeline {
-		fmt.Println("LOG: Timeline item id:", item.Id())
-		//TODO the commentId will never match the timeline item id as the
-		//timelineitem is is op.Target but the commentId is target interleaved
-		//with the bug id!
-		// - Maybe interleave timelineid with snapshot (here)?
-		// - Or separate TimelineId for check...
-		//TODO The timelineitem id is already interleaved with the snapshot id
-		//TODO EditCommentOperation must take a CombinedId as target! But this
-		//conflicts micheals andere here
-		//https://github.com/MichaelMure/git-bug/issues/653#issuecomment-826707391
-
-		//NOTE show_bug.go sparateId only affects the TermUI, not the WebUI!
-		//NOTE GOT THE ERROR!!!
-		//The timeline id (idem.ID) does not match commentId, as commentId
-		//does not correctly reconstruct. Strange is, that the op.TargetId
-		//shouldn't be the Timeline id, as the timeline id is already split...
-		//(see HEAD commit)
-		// SnapshotId: 54bc19b8fae02b4b15dfc5a6d1e7c1ca3ff133de86ef03ab79fb4968dced11a8
-		// op.TargetId: 5544bbc19cb8fa1e02b94b15bdfc58a6d1fe7c1aca3fef1330de862ef03bab79
-		// Created commentId: 5545b4c194b8fabe02bb4b15cdfc51a6d19e7c1cca3fbf1338de86fef03aab79
-		// Timeline item id: 5544bbc19cb8fa1e02b94b15bdfc58a6d1fe7c1aca3fef1330de862ef03bab79
-		if item.Id().HasPrefix(commentId) {
+		if item.Id() == commentId {
 			target = snapshot.Timeline[i]
 			break
 		}
 	}
 
 	if target == nil {
-		fmt.Println("LOG: Edit is a noop!")
 		// Target not found, edit is a no-op
 		return
 	}
@@ -116,7 +91,6 @@ func (op *EditCommentOperation) Validate() error {
 	}
 
 	if err := op.Target.Validate(); err != nil {
-		fmt.Println("LOG: Validate:", op.Target)
 		return errors.Wrap(err, "target hash is invalid")
 	}
 

--- a/bug/op_label_change.go
+++ b/bug/op_label_change.go
@@ -58,7 +58,7 @@ AddLoop:
 	})
 
 	item := &LabelChangeTimelineItem{
-		id:       op.Id(),
+		id:       entity.CombineIds(snapshot.Id(), op.Id()),
 		Author:   op.Author_,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Added:    op.Added,
@@ -133,14 +133,14 @@ func NewLabelChangeOperation(author identity.Interface, unixTime int64, added, r
 }
 
 type LabelChangeTimelineItem struct {
-	id       entity.Id
+	id       entity.CombinedId
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Added    []Label
 	Removed  []Label
 }
 
-func (l LabelChangeTimelineItem) Id() entity.Id {
+func (l LabelChangeTimelineItem) Id() entity.CombinedId {
 	return l.id
 }
 
@@ -208,7 +208,7 @@ func ChangeLabels(b Interface, author identity.Interface, unixTime int64, add, r
 }
 
 // ForceChangeLabels is a convenience function to apply the operation
-// The difference with ChangeLabels is that no checks of deduplications are done. You are entirely
+// The difference with ChangeLabels is that no checks for deduplication are done. You are entirely
 // responsible of what you are doing. In the general case, you want to use ChangeLabels instead.
 // The intended use of this function is to allow importers to create legal but unexpected label changes,
 // like removing a label with no information of when it was added before.

--- a/bug/op_set_status.go
+++ b/bug/op_set_status.go
@@ -27,7 +27,7 @@ func (op *SetStatusOperation) Apply(snapshot *Snapshot) {
 	snapshot.addActor(op.Author_)
 
 	item := &SetStatusTimelineItem{
-		id:       op.Id(),
+		id:       entity.CombineIds(snapshot.Id(), op.Id()),
 		Author:   op.Author_,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Status:   op.Status,
@@ -86,13 +86,13 @@ func NewSetStatusOp(author identity.Interface, unixTime int64, status Status) *S
 }
 
 type SetStatusTimelineItem struct {
-	id       entity.Id
+	id       entity.CombinedId
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Status   Status
 }
 
-func (s SetStatusTimelineItem) Id() entity.Id {
+func (s SetStatusTimelineItem) Id() entity.CombinedId {
 	return s.id
 }
 

--- a/bug/op_set_title.go
+++ b/bug/op_set_title.go
@@ -29,7 +29,7 @@ func (op *SetTitleOperation) Apply(snapshot *Snapshot) {
 	snapshot.addActor(op.Author_)
 
 	item := &SetTitleTimelineItem{
-		id:       op.Id(),
+		id:       entity.CombineIds(snapshot.Id(), op.Id()),
 		Author:   op.Author_,
 		UnixTime: timestamp.Timestamp(op.UnixTime),
 		Title:    op.Title,
@@ -100,14 +100,14 @@ func NewSetTitleOp(author identity.Interface, unixTime int64, title string, was 
 }
 
 type SetTitleTimelineItem struct {
-	id       entity.Id
+	id       entity.CombinedId
 	Author   identity.Interface
 	UnixTime timestamp.Timestamp
 	Title    string
 	Was      string
 }
 
-func (s SetTitleTimelineItem) Id() entity.Id {
+func (s SetTitleTimelineItem) Id() entity.CombinedId {
 	return s.id
 }
 

--- a/bug/snapshot.go
+++ b/bug/snapshot.go
@@ -50,7 +50,7 @@ func (snap *Snapshot) GetCreateMetadata(key string) (string, bool) {
 }
 
 // SearchTimelineItem will search in the timeline for an item matching the given hash
-func (snap *Snapshot) SearchTimelineItem(id entity.Id) (TimelineItem, error) {
+func (snap *Snapshot) SearchTimelineItem(id entity.CombinedId) (TimelineItem, error) {
 	for i := range snap.Timeline {
 		if snap.Timeline[i].Id() == id {
 			return snap.Timeline[i], nil
@@ -61,7 +61,7 @@ func (snap *Snapshot) SearchTimelineItem(id entity.Id) (TimelineItem, error) {
 }
 
 // SearchComment will search for a comment matching the given hash
-func (snap *Snapshot) SearchComment(id entity.Id) (*Comment, error) {
+func (snap *Snapshot) SearchComment(id entity.CombinedId) (*Comment, error) {
 	for _, c := range snap.Comments {
 		if c.id == id {
 			return &c, nil

--- a/bug/timeline.go
+++ b/bug/timeline.go
@@ -11,7 +11,7 @@ import (
 
 type TimelineItem interface {
 	// ID return the identifier of the item
-	Id() entity.Id
+	Id() entity.CombinedId
 }
 
 // CommentHistoryStep hold one version of a message in the history
@@ -27,7 +27,7 @@ type CommentHistoryStep struct {
 // CommentTimelineItem is a TimelineItem that holds a Comment and its edition history
 type CommentTimelineItem struct {
 	// id should be the same as in Comment
-	id        entity.Id
+	id        entity.CombinedId
 	Author    identity.Interface
 	Message   string
 	Files     []repository.Hash
@@ -53,7 +53,7 @@ func NewCommentTimelineItem(comment Comment) CommentTimelineItem {
 	}
 }
 
-func (c *CommentTimelineItem) Id() entity.Id {
+func (c *CommentTimelineItem) Id() entity.CombinedId {
 	return c.id
 }
 

--- a/cache/identity_excerpt.go
+++ b/cache/identity_excerpt.go
@@ -51,7 +51,7 @@ func (i *IdentityExcerpt) DisplayName() string {
 
 // Match matches a query with the identity name, login and ID prefixes
 func (i *IdentityExcerpt) Match(query string) bool {
-	return i.Id.HasPrefix(query) ||
+	return i.Id.HasPrefix(entity.Id(query)) ||
 		strings.Contains(strings.ToLower(i.Name), query) ||
 		strings.Contains(strings.ToLower(i.Login), query)
 }

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -263,7 +263,7 @@ func (c *RepoCache) resolveBugMatcher(f func(*BugExcerpt) bool) (entity.Id, erro
 // ResolveComment search for a Bug/Comment combination matching the merged
 // bug/comment Id prefix. Returns the Bug containing the Comment and the Comment's
 // Id.
-func (c *RepoCache) ResolveComment(prefix string) (*BugCache, entity.Id, error) {
+func (c *RepoCache) ResolveComment(prefix string) (*BugCache, entity.CombinedId, error) {
 	bugPrefix, _ := entity.SeparateIds(prefix)
 	bugCandidate := make([]entity.Id, 0, 5)
 
@@ -277,7 +277,7 @@ func (c *RepoCache) ResolveComment(prefix string) (*BugCache, entity.Id, error) 
 	c.muBug.RUnlock()
 
 	matchingBugIds := make([]entity.Id, 0, 5)
-	matchingCommentId := entity.UnsetId
+	matchingCommentId := entity.UnsetCombinedId
 	var matchingBug *BugCache
 
 	// search for matching comments
@@ -286,7 +286,7 @@ func (c *RepoCache) ResolveComment(prefix string) (*BugCache, entity.Id, error) 
 	for _, bugId := range bugCandidate {
 		b, err := c.ResolveBug(bugId)
 		if err != nil {
-			return nil, entity.UnsetId, err
+			return nil, entity.UnsetCombinedId, err
 		}
 
 		for _, comment := range b.Snapshot().Comments {
@@ -299,9 +299,9 @@ func (c *RepoCache) ResolveComment(prefix string) (*BugCache, entity.Id, error) 
 	}
 
 	if len(matchingBugIds) > 1 {
-		return nil, entity.UnsetId, entity.NewErrMultipleMatch("bug/comment", matchingBugIds)
+		return nil, entity.UnsetCombinedId, entity.NewErrMultipleMatch("bug/comment", matchingBugIds)
 	} else if len(matchingBugIds) == 0 {
-		return nil, entity.UnsetId, errors.New("comment doesn't exist")
+		return nil, entity.UnsetCombinedId, errors.New("comment doesn't exist")
 	}
 
 	return matchingBug, matchingCommentId, nil

--- a/cache/repo_cache_bug.go
+++ b/cache/repo_cache_bug.go
@@ -197,7 +197,7 @@ func (c *RepoCache) evictIfNeeded() {
 
 // ResolveBugExcerptPrefix retrieve a BugExcerpt matching an id prefix. It fails if multiple
 // bugs match.
-func (c *RepoCache) ResolveBugExcerptPrefix(prefix string) (*BugExcerpt, error) {
+func (c *RepoCache) ResolveBugExcerptPrefix(prefix entity.Id) (*BugExcerpt, error) {
 	return c.ResolveBugExcerptMatcher(func(excerpt *BugExcerpt) bool {
 		return excerpt.Id.HasPrefix(prefix)
 	})
@@ -205,7 +205,7 @@ func (c *RepoCache) ResolveBugExcerptPrefix(prefix string) (*BugExcerpt, error) 
 
 // ResolveBugPrefix retrieve a bug matching an id prefix. It fails if multiple
 // bugs match.
-func (c *RepoCache) ResolveBugPrefix(prefix string) (*BugCache, error) {
+func (c *RepoCache) ResolveBugPrefix(prefix entity.Id) (*BugCache, error) {
 	return c.ResolveBugMatcher(func(excerpt *BugExcerpt) bool {
 		return excerpt.Id.HasPrefix(prefix)
 	})
@@ -263,7 +263,7 @@ func (c *RepoCache) resolveBugMatcher(f func(*BugExcerpt) bool) (entity.Id, erro
 // ResolveComment search for a Bug/Comment combination matching the merged
 // bug/comment Id prefix. Returns the Bug containing the Comment and the Comment's
 // Id.
-func (c *RepoCache) ResolveComment(prefix string) (*BugCache, entity.CombinedId, error) {
+func (c *RepoCache) ResolveComment(prefix entity.CombinedId) (*BugCache, entity.CombinedId, error) {
 	bugPrefix, _ := entity.SeparateIds(prefix)
 	bugCandidate := make([]entity.Id, 0, 5)
 
@@ -498,7 +498,7 @@ func (c *RepoCache) NewBugRaw(author *IdentityCache, unixTime int64, title strin
 }
 
 // RemoveBug removes a bug from the cache and repo given a bug id prefix
-func (c *RepoCache) RemoveBug(prefix string) error {
+func (c *RepoCache) RemoveBug(prefix entity.Id) error {
 	c.muBug.RLock()
 
 	b, err := c.ResolveBugPrefix(prefix)

--- a/cache/repo_cache_identity.go
+++ b/cache/repo_cache_identity.go
@@ -132,7 +132,7 @@ func (c *RepoCache) ResolveIdentity(id entity.Id) (*IdentityCache, error) {
 
 // ResolveIdentityExcerptPrefix retrieve a IdentityExcerpt matching an id prefix.
 // It fails if multiple identities match.
-func (c *RepoCache) ResolveIdentityExcerptPrefix(prefix string) (*IdentityExcerpt, error) {
+func (c *RepoCache) ResolveIdentityExcerptPrefix(prefix entity.Id) (*IdentityExcerpt, error) {
 	return c.ResolveIdentityExcerptMatcher(func(excerpt *IdentityExcerpt) bool {
 		return excerpt.Id.HasPrefix(prefix)
 	})
@@ -140,7 +140,7 @@ func (c *RepoCache) ResolveIdentityExcerptPrefix(prefix string) (*IdentityExcerp
 
 // ResolveIdentityPrefix retrieve an Identity matching an id prefix.
 // It fails if multiple identities match.
-func (c *RepoCache) ResolveIdentityPrefix(prefix string) (*IdentityCache, error) {
+func (c *RepoCache) ResolveIdentityPrefix(prefix entity.Id) (*IdentityCache, error) {
 	return c.ResolveIdentityMatcher(func(excerpt *IdentityExcerpt) bool {
 		return excerpt.Id.HasPrefix(prefix)
 	})

--- a/cache/repo_cache_test.go
+++ b/cache/repo_cache_test.go
@@ -62,14 +62,14 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.ResolveIdentityExcerpt(iden1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveIdentityPrefix(iden1.Id().String()[:10])
+	_, err = cache.ResolveIdentityPrefix(iden1.Id()[:10])
 	require.NoError(t, err)
 
 	_, err = cache.ResolveBug(bug1.Id())
 	require.NoError(t, err)
 	_, err = cache.ResolveBugExcerpt(bug1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveBugPrefix(bug1.Id().String()[:10])
+	_, err = cache.ResolveBugPrefix(bug1.Id()[:10])
 	require.NoError(t, err)
 
 	// Querying
@@ -100,14 +100,14 @@ func TestCache(t *testing.T) {
 	require.NoError(t, err)
 	_, err = cache.ResolveIdentityExcerpt(iden1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveIdentityPrefix(iden1.Id().String()[:10])
+	_, err = cache.ResolveIdentityPrefix(iden1.Id()[:10])
 	require.NoError(t, err)
 
 	_, err = cache.ResolveBug(bug1.Id())
 	require.NoError(t, err)
 	_, err = cache.ResolveBugExcerpt(bug1.Id())
 	require.NoError(t, err)
-	_, err = cache.ResolveBugPrefix(bug1.Id().String()[:10])
+	_, err = cache.ResolveBugPrefix(bug1.Id()[:10])
 	require.NoError(t, err)
 }
 
@@ -210,7 +210,7 @@ func TestRemove(t *testing.T) {
 	_, err = repoCache.Fetch("remoteB")
 	require.NoError(t, err)
 
-	err = repoCache.RemoveBug(b1.Id().String())
+	err = repoCache.RemoveBug(b1.Id())
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(repoCache.bugs))
 	assert.Equal(t, 1, len(repoCache.bugExcerpts))

--- a/commands/bridge_auth_addtoken.go
+++ b/commands/bridge_auth_addtoken.go
@@ -14,6 +14,7 @@ import (
 	"github.com/MichaelMure/git-bug/bridge/core"
 	"github.com/MichaelMure/git-bug/bridge/core/auth"
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 type bridgeAuthAddTokenOptions struct {
@@ -90,7 +91,7 @@ func runBridgeAuthAddToken(env *Env, opts bridgeAuthAddTokenOptions, args []stri
 	if opts.user == "" {
 		user, err = env.backend.GetUserIdentity()
 	} else {
-		user, err = env.backend.ResolveIdentityPrefix(opts.user)
+		user, err = env.backend.ResolveIdentityPrefix(entity.Id(opts.user))
 	}
 	if err != nil {
 		return err

--- a/commands/comment_edit.go
+++ b/commands/comment_edit.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/MichaelMure/git-bug/input"
 )
 
@@ -67,7 +68,8 @@ func runCommentEdit(env *Env, opts commentEditOptions, args []string) error {
 		}
 	}
 
-	_, err = b.EditComment(commentId, opts.message)
+	_, id := entity.SeparateIds(string(commentId))
+	_, err = b.EditComment(entity.Id(id), opts.message)
 	if err != nil {
 		return err
 	}

--- a/commands/comment_edit.go
+++ b/commands/comment_edit.go
@@ -70,7 +70,19 @@ func runCommentEdit(env *Env, opts commentEditOptions, args []string) error {
 		}
 	}
 
-	_, opId := entity.SeparateIds(commentId)
+	_, opIdPrefix := entity.SeparateIds(commentId)
+	// TODO extract the find logic to EditCommentOperation where the TermUI
+	// etc would also benefit of it. Unfortunatly using snapshot.Operations
+	// results in nil dereference error...
+	var opId entity.Id
+	// Find the full operation id via the prefix
+	for _, operation := range b.Snapshot().Operations {
+		if operation.Id().HasPrefix(opIdPrefix) {
+			opId = operation.Id()
+			break
+		}
+	}
+
 	_, err = b.EditComment(opId, opts.message)
 	if err != nil {
 		return err

--- a/commands/comment_edit.go
+++ b/commands/comment_edit.go
@@ -41,7 +41,9 @@ func newCommentEditCommand() *cobra.Command {
 }
 
 func runCommentEdit(env *Env, opts commentEditOptions, args []string) error {
-	b, commentId, err := env.backend.ResolveComment(args[0])
+	//TODO Is args[0] the correct CombinedId or do I first have to construct
+	//the right one? Not that args[0] is actually the OperationId.
+	b, commentId, err := env.backend.ResolveComment(entity.CombinedId(args[0]))
 	if err != nil {
 		return err
 	}
@@ -68,8 +70,8 @@ func runCommentEdit(env *Env, opts commentEditOptions, args []string) error {
 		}
 	}
 
-	_, id := entity.SeparateIds(string(commentId))
-	_, err = b.EditComment(entity.Id(id), opts.message)
+	_, opId := entity.SeparateIds(commentId)
+	_, err = b.EditComment(opId, opts.message)
 	if err != nil {
 		return err
 	}

--- a/commands/ls-id.go
+++ b/commands/ls-id.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 func newLsIdCommand() *cobra.Command {
@@ -26,7 +28,7 @@ func runLsId(env *Env, args []string) error {
 	}
 
 	for _, id := range env.backend.AllBugsIds() {
-		if prefix == "" || id.HasPrefix(prefix) {
+		if prefix == "" || id.HasPrefix(entity.Id(prefix)) {
 			env.out.Println(id)
 		}
 	}

--- a/commands/rm.go
+++ b/commands/rm.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"errors"
 
+	"github.com/MichaelMure/git-bug/entity"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +31,7 @@ func runRm(env *Env, args []string) (err error) {
 		return errors.New("you must provide a bug prefix to remove")
 	}
 
-	err = env.backend.RemoveBug(args[0])
+	err = env.backend.RemoveBug(entity.Id(args[0]))
 
 	if err != nil {
 		return

--- a/commands/select.go
+++ b/commands/select.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	_select "github.com/MichaelMure/git-bug/commands/select"
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 func newSelectCommand() *cobra.Command {
@@ -43,7 +44,7 @@ func runSelect(env *Env, args []string) error {
 
 	prefix := args[0]
 
-	b, err := env.backend.ResolveBugPrefix(prefix)
+	b, err := env.backend.ResolveBugPrefix(entity.Id(prefix))
 	if err != nil {
 		return err
 	}

--- a/commands/select/select.go
+++ b/commands/select/select.go
@@ -28,7 +28,7 @@ var ErrNoValidId = errors.New("you must provide a bug id or use the \"select\" c
 func ResolveBug(repo *cache.RepoCache, args []string) (*cache.BugCache, []string, error) {
 	// At first, try to use the first argument as a bug prefix
 	if len(args) > 0 {
-		b, err := repo.ResolveBugPrefix(args[0])
+		b, err := repo.ResolveBugPrefix(entity.Id(args[0]))
 
 		if err == nil {
 			return b, args[1:], nil

--- a/commands/user.go
+++ b/commands/user.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/MichaelMure/git-bug/cache"
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 type userOptions struct {
@@ -47,7 +48,7 @@ func runUser(env *Env, opts userOptions, args []string) error {
 	var id *cache.IdentityCache
 	var err error
 	if len(args) == 1 {
-		id, err = env.backend.ResolveIdentityPrefix(args[0])
+		id, err = env.backend.ResolveIdentityPrefix(entity.Id(args[0]))
 	} else {
 		id, err = env.backend.GetUserIdentity()
 	}

--- a/commands/user_adopt.go
+++ b/commands/user_adopt.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/MichaelMure/git-bug/entity"
 )
 
 func newUserAdoptCommand() *cobra.Command {
@@ -23,7 +25,7 @@ func newUserAdoptCommand() *cobra.Command {
 func runUserAdopt(env *Env, args []string) error {
 	prefix := args[0]
 
-	i, err := env.backend.ResolveIdentityPrefix(prefix)
+	i, err := env.backend.ResolveIdentityPrefix(entity.Id(prefix))
 	if err != nil {
 		return err
 	}

--- a/entity/id.go
+++ b/entity/id.go
@@ -79,21 +79,3 @@ func (i Id) Validate() error {
 	}
 	return nil
 }
-
-/*
- * Sorting
- */
-
-type Alphabetical []Id
-
-func (a Alphabetical) Len() int {
-	return len(a)
-}
-
-func (a Alphabetical) Less(i, j int) bool {
-	return a[i] < a[j]
-}
-
-func (a Alphabetical) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}

--- a/entity/id.go
+++ b/entity/id.go
@@ -38,8 +38,8 @@ func (i Id) Human() string {
 	return fmt.Sprintf(format, i)
 }
 
-func (i Id) HasPrefix(prefix string) bool {
-	return strings.HasPrefix(string(i), prefix)
+func (i Id) HasPrefix(prefix Id) bool {
+	return strings.HasPrefix(string(i), string(prefix))
 }
 
 // UnmarshalGQL implement the Unmarshaler interface for gqlgen

--- a/entity/id_interleaved.go
+++ b/entity/id_interleaved.go
@@ -1,8 +1,72 @@
 package entity
 
 import (
+	"fmt"
+	"io"
 	"strings"
+
+	"github.com/pkg/errors"
 )
+
+const UnsetCombinedId = CombinedId("unset")
+
+// CombinedId is an Id holding information from both a primary Id and a secondary Id.
+// While it looks like a regular Id, do not just cast from one to another.
+// Instead, use CombineIds and SeparateIds to create it and split it.
+type CombinedId string
+
+// String return the identifier as a string
+func (ci CombinedId) String() string {
+	return string(ci)
+}
+
+// Human return the identifier, shortened for human consumption
+func (ci CombinedId) Human() string {
+	format := fmt.Sprintf("%%.%ds", humanIdLength)
+	return fmt.Sprintf(format, ci)
+}
+
+func (ci CombinedId) HasPrefix(prefix string) bool {
+	return strings.HasPrefix(string(ci), prefix)
+}
+
+// UnmarshalGQL implement the Unmarshaler interface for gqlgen
+func (ci *CombinedId) UnmarshalGQL(v interface{}) error {
+	_, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("IDs must be strings")
+	}
+
+	*ci = v.(CombinedId)
+
+	if err := ci.Validate(); err != nil {
+		return errors.Wrap(err, "invalid ID")
+	}
+
+	return nil
+}
+
+// MarshalGQL implement the Marshaler interface for gqlgen
+func (ci CombinedId) MarshalGQL(w io.Writer) {
+	_, _ = w.Write([]byte(`"` + ci.String() + `"`))
+}
+
+// IsValid tell if the Id is valid
+func (ci CombinedId) Validate() error {
+	// Special case to detect outdated repo
+	if len(ci) == 40 {
+		return fmt.Errorf("outdated repository format, please use https://github.com/MichaelMure/git-bug-migration to upgrade")
+	}
+	if len(ci) != idLength {
+		return fmt.Errorf("invalid length")
+	}
+	for _, r := range ci {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return fmt.Errorf("invalid character")
+		}
+	}
+	return nil
+}
 
 // CombineIds compute a merged Id holding information from both the primary Id
 // and the secondary Id.
@@ -32,7 +96,7 @@ import (
 // 7:    4P, 3S
 // 10:   6P, 4S
 // 16:  11P, 5S
-func CombineIds(primary Id, secondary Id) Id {
+func CombineIds(primary Id, secondary Id) CombinedId {
 	var id strings.Builder
 
 	for i := 0; i < idLength; i++ {
@@ -46,7 +110,7 @@ func CombineIds(primary Id, secondary Id) Id {
 		}
 	}
 
-	return Id(id.String())
+	return CombinedId(id.String())
 }
 
 // SeparateIds extract primary and secondary prefix from an arbitrary length prefix

--- a/entity/id_interleaved.go
+++ b/entity/id_interleaved.go
@@ -26,8 +26,8 @@ func (ci CombinedId) Human() string {
 	return fmt.Sprintf(format, ci)
 }
 
-func (ci CombinedId) HasPrefix(prefix string) bool {
-	return strings.HasPrefix(string(ci), prefix)
+func (ci CombinedId) HasPrefix(prefix CombinedId) bool {
+	return strings.HasPrefix(string(ci), string(prefix))
 }
 
 // UnmarshalGQL implement the Unmarshaler interface for gqlgen
@@ -115,7 +115,7 @@ func CombineIds(primary Id, secondary Id) CombinedId {
 
 // SeparateIds extract primary and secondary prefix from an arbitrary length prefix
 // of an Id created with CombineIds.
-func SeparateIds(prefix string) (primaryPrefix string, secondaryPrefix string) {
+func SeparateIds(prefix CombinedId) (primaryPrefix Id, secondaryPrefix Id) {
 	var primary strings.Builder
 	var secondary strings.Builder
 
@@ -128,5 +128,5 @@ func SeparateIds(prefix string) (primaryPrefix string, secondaryPrefix string) {
 		}
 	}
 
-	return primary.String(), secondary.String()
+	return Id(primary.String()), Id(secondary.String())
 }

--- a/entity/id_interleaved_test.go
+++ b/entity/id_interleaved_test.go
@@ -9,7 +9,7 @@ import (
 func TestInterleaved(t *testing.T) {
 	primary := Id("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWX______________")
 	secondary := Id("YZ0123456789+/________________________________________________")
-	expectedId := Id("aYbZc0def1ghij2klmn3opqr4stuv5wxyz6ABCD7EFGH8IJKL9MNOP+QRST/UVWX")
+	expectedId := CombinedId("aYbZc0def1ghij2klmn3opqr4stuv5wxyz6ABCD7EFGH8IJKL9MNOP+QRST/UVWX")
 
 	interleaved := CombineIds(primary, secondary)
 	require.Equal(t, expectedId, interleaved)

--- a/entity/id_interleaved_test.go
+++ b/entity/id_interleaved_test.go
@@ -15,22 +15,22 @@ func TestInterleaved(t *testing.T) {
 	require.Equal(t, expectedId, interleaved)
 
 	// full length
-	splitPrimary, splitSecondary := SeparateIds(interleaved.String())
+	splitPrimary, splitSecondary := SeparateIds(interleaved)
 	require.Equal(t, string(primary[:50]), splitPrimary)
 	require.Equal(t, string(secondary[:14]), splitSecondary)
 
 	// partial
-	splitPrimary, splitSecondary = SeparateIds(string(expectedId[:7]))
+	splitPrimary, splitSecondary = SeparateIds(expectedId[:7])
 	require.Equal(t, string(primary[:4]), splitPrimary)
 	require.Equal(t, string(secondary[:3]), splitSecondary)
 
 	// partial
-	splitPrimary, splitSecondary = SeparateIds(string(expectedId[:10]))
+	splitPrimary, splitSecondary = SeparateIds(expectedId[:10])
 	require.Equal(t, string(primary[:6]), splitPrimary)
 	require.Equal(t, string(secondary[:4]), splitSecondary)
 
 	// partial
-	splitPrimary, splitSecondary = SeparateIds(string(expectedId[:16]))
+	splitPrimary, splitSecondary = SeparateIds(expectedId[:16])
 	require.Equal(t, string(primary[:11]), splitPrimary)
 	require.Equal(t, string(secondary[:5]), splitSecondary)
 }

--- a/entity/id_interleaved_test.go
+++ b/entity/id_interleaved_test.go
@@ -16,21 +16,21 @@ func TestInterleaved(t *testing.T) {
 
 	// full length
 	splitPrimary, splitSecondary := SeparateIds(interleaved)
-	require.Equal(t, string(primary[:50]), splitPrimary)
-	require.Equal(t, string(secondary[:14]), splitSecondary)
+	require.Equal(t, primary[:50], splitPrimary)
+	require.Equal(t, secondary[:14], splitSecondary)
 
 	// partial
 	splitPrimary, splitSecondary = SeparateIds(expectedId[:7])
-	require.Equal(t, string(primary[:4]), splitPrimary)
-	require.Equal(t, string(secondary[:3]), splitSecondary)
+	require.Equal(t, primary[:4], splitPrimary)
+	require.Equal(t, secondary[:3], splitSecondary)
 
 	// partial
 	splitPrimary, splitSecondary = SeparateIds(expectedId[:10])
-	require.Equal(t, string(primary[:6]), splitPrimary)
-	require.Equal(t, string(secondary[:4]), splitSecondary)
+	require.Equal(t, primary[:6], splitPrimary)
+	require.Equal(t, secondary[:4], splitSecondary)
 
 	// partial
 	splitPrimary, splitSecondary = SeparateIds(expectedId[:16])
-	require.Equal(t, string(primary[:11]), splitPrimary)
-	require.Equal(t, string(secondary[:5]), splitSecondary)
+	require.Equal(t, primary[:11], splitPrimary)
+	require.Equal(t, secondary[:5], splitSecondary)
 }

--- a/go.sum
+++ b/go.sum
@@ -544,6 +544,7 @@ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -701,6 +702,7 @@ golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200825202427-b303f430e36d h1:W07d4xkoAUSNOkOzdzXCdFGxT7o2rW4q8M34tB2i//k=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -645,7 +645,7 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return nil
 	}
 
-	op, err := snap.SearchTimelineItem(entity.Id(sb.selected))
+	op, err := snap.SearchTimelineItem(entity.CombinedId(sb.selected))
 	if err != nil {
 		return err
 	}

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -650,7 +650,19 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 
-	_, opId := entity.SeparateIds(item.Id())
+	_, opIdPrefix := entity.SeparateIds(item.Id())
+	// TODO extract the find logic to EditCommentOperation where the TermUI
+	// etc would also benefit of it. Unfortunatly using snapshot.Operations
+	// results in nil dereference error...
+	var opId entity.Id
+	// Find the full operation id via the prefix
+	for _, operation := range snap.Operations {
+		if operation.Id().HasPrefix(opIdPrefix) {
+			opId = operation.Id()
+			break
+		}
+	}
+
 	switch item := item.(type) {
 	case *bug.AddCommentTimelineItem:
 		return editCommentWithEditor(sb.bug, opId, item.Message)

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -650,7 +650,10 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 
-	_, opId := entity.SeparateIds(item.Id())
+	bugId, opId := entity.SeparateIds(item.Id())
+	fmt.Println("LOG: SB SnapshotId:", item.Id())
+	fmt.Println("LOG: SB bugId:", bugId)
+	fmt.Println("LOG: SB opId:", opId)
 	switch item := item.(type) {
 	case *bug.AddCommentTimelineItem:
 		return editCommentWithEditor(sb.bug, opId, item.Message)

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -650,10 +650,7 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return err
 	}
 
-	bugId, opId := entity.SeparateIds(item.Id())
-	fmt.Println("LOG: SB SnapshotId:", item.Id())
-	fmt.Println("LOG: SB bugId:", bugId)
-	fmt.Println("LOG: SB opId:", opId)
+	_, opId := entity.SeparateIds(item.Id())
 	switch item := item.(type) {
 	case *bug.AddCommentTimelineItem:
 		return editCommentWithEditor(sb.bug, opId, item.Message)

--- a/termui/show_bug.go
+++ b/termui/show_bug.go
@@ -645,16 +645,17 @@ func (sb *showBug) edit(g *gocui.Gui, v *gocui.View) error {
 		return nil
 	}
 
-	op, err := snap.SearchTimelineItem(entity.CombinedId(sb.selected))
+	item, err := snap.SearchTimelineItem(entity.CombinedId(sb.selected))
 	if err != nil {
 		return err
 	}
 
-	switch op := op.(type) {
+	_, opId := entity.SeparateIds(item.Id())
+	switch item := item.(type) {
 	case *bug.AddCommentTimelineItem:
-		return editCommentWithEditor(sb.bug, op.Id(), op.Message)
+		return editCommentWithEditor(sb.bug, opId, item.Message)
 	case *bug.CreateTimelineItem:
-		return editCommentWithEditor(sb.bug, op.Id(), op.Message)
+		return editCommentWithEditor(sb.bug, opId, item.Message)
 	case *bug.LabelChangeTimelineItem:
 		return sb.editLabels(g, snap)
 	}

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -274,8 +274,8 @@ func editCommentWithEditor(bug *cache.BugCache, target entity.CombinedId, preMes
 	} else if message == preMessage {
 		ui.msgPopup.Activate(msgPopupErrorTitle, "No changes found, aborting.")
 	} else {
-		_, opId := entity.SeparateIds(string(target))
-		_, err := bug.EditComment(entity.Id(opId), text.Cleanup(message))
+		_, opId := entity.SeparateIds(target)
+		_, err := bug.EditComment(opId, text.Cleanup(message))
 		if err != nil {
 			return err
 		}

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -250,7 +250,7 @@ func addCommentWithEditor(bug *cache.BugCache) error {
 	return errTerminateMainloop
 }
 
-func editCommentWithEditor(bug *cache.BugCache, target entity.CombinedId, preMessage string) error {
+func editCommentWithEditor(bug *cache.BugCache, target entity.Id, preMessage string) error {
 	// This is somewhat hacky.
 	// As there is no way to pause gocui, run the editor and restart gocui,
 	// we have to stop it entirely and start a new one later.
@@ -274,8 +274,7 @@ func editCommentWithEditor(bug *cache.BugCache, target entity.CombinedId, preMes
 	} else if message == preMessage {
 		ui.msgPopup.Activate(msgPopupErrorTitle, "No changes found, aborting.")
 	} else {
-		_, opId := entity.SeparateIds(target)
-		_, err := bug.EditComment(opId, text.Cleanup(message))
+		_, err := bug.EditComment(target, text.Cleanup(message))
 		if err != nil {
 			return err
 		}

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -250,7 +250,7 @@ func addCommentWithEditor(bug *cache.BugCache) error {
 	return errTerminateMainloop
 }
 
-func editCommentWithEditor(bug *cache.BugCache, target entity.Id, preMessage string) error {
+func editCommentWithEditor(bug *cache.BugCache, target entity.CombinedId, preMessage string) error {
 	// This is somewhat hacky.
 	// As there is no way to pause gocui, run the editor and restart gocui,
 	// we have to stop it entirely and start a new one later.
@@ -274,7 +274,8 @@ func editCommentWithEditor(bug *cache.BugCache, target entity.Id, preMessage str
 	} else if message == preMessage {
 		ui.msgPopup.Activate(msgPopupErrorTitle, "No changes found, aborting.")
 	} else {
-		_, err := bug.EditComment(target, text.Cleanup(message))
+		_, opId := entity.SeparateIds(string(target))
+		_, err := bug.EditComment(entity.Id(opId), text.Cleanup(message))
 		if err != nil {
 			return err
 		}

--- a/webui/src/pages/bug/EditCommentForm.tsx
+++ b/webui/src/pages/bug/EditCommentForm.tsx
@@ -53,6 +53,9 @@ function EditCommentForm({ bug, comment, onCancel, onPostSubmit }: Props) {
   const classes = useStyles({ loading });
   const form = useRef<HTMLFormElement>(null);
 
+  console.log('bugId:', bug.id);
+  console.log('commentId:', comment.id);
+
   const submit = () => {
     editComment({
       variables: {


### PR DESCRIPTION
Possible improvements:

- [x] Entity::CombineIds should take Entity::Id's as arguments, not strings
- [x] Entity::SeparateIds should return an Entity::Id not a string
- [ ] A comment should have a CommentId, which should provide operations to extract the BugId or OperationId. So that using CombeIds/SeparateIds is an implmentation detail.
- [x] RepoCacheBug::ResolveComment should return an Entity::Id not a combined Id, as the user of this function already has a reference to the bug, rendering the CombinedId useless. Unless the CombinedId is the real CommentId, but then this Id should provide functions for easier handling, as mentioned in previous point.